### PR TITLE
25.13

### DIFF
--- a/Link.aspx.cs
+++ b/Link.aspx.cs
@@ -705,7 +705,7 @@ namespace ipsw
             lblSelection.Font.Bold = true;
             lblSelection.Font.Size = 15;
 
-            lblSelectionComment.Text = "You have selected OTA <b>" + rblOptions.SelectedItem.ToString() + " " + ddlVersionOTA.SelectedItem.ToString();
+            lblSelectionComment.Text = "You have selected OTA <b>" + rblOptions.SelectedItem.ToString() + " " + ddlVersionOTA.SelectedItem.ToString() + "</b>";
             btnRetrieve.Text = "Retrieve";
             btnRetrieve.Visible = true;
 

--- a/MANUAL_QA.md
+++ b/MANUAL_QA.md
@@ -1,0 +1,7 @@
+# Manual QA
+
+## OTA version selection formatting
+1. Open the site in a browser and navigate to the Link page.
+2. Choose the **Version (OTA)** option.
+3. Select any OTA version from the dropdown.
+4. Verify that only the chosen version text in the selection summary is bolded and that the rest of the page retains its normal styling.


### PR DESCRIPTION
## Summary
- ensure the OTA selection summary text closes the bold tag so formatting stays scoped
- document manual QA steps for verifying the OTA selection formatting

## Testing
- not run (legacy .NET WebForms app)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918990f2988832ab42f6e82e5a299cf)